### PR TITLE
Included a fancy Discord banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # KiraBot
 
+[![](https://discordapp.com/api/guilds/332143783825375254/embed.png?style=banner2)](https://discord.gg/PSJhtwM)
+
 [![Documentation Status](https://readthedocs.org/projects/kirabot/badge/?version=latest)](http://kirabot.readthedocs.io/en/latest/?badge=latest)
 
 This is my bot which is under construction. I'm quite new to the Discord.Net library and C# itself so if you would like to help me develop this, please do get in contact!


### PR DESCRIPTION
This banner acts as the official #KiraBot Support server invitation link.